### PR TITLE
Deletes old db on thread switch w/ reset method

### DIFF
--- a/hub-threaddb-chat/README.md
+++ b/hub-threaddb-chat/README.md
@@ -1,0 +1,30 @@
+## Setup
+
+This project is already setup to run on in the browser. All you need to do is `npm install`, and then `npm run start`... almost! Read on for further steps.
+
+### Textile Hub Key & Secret
+
+In order to run your own app, you'll want to use your own app keys. You can create these from the Textile CLI. Check out the docs for details here:
+
+- https://docs.textile.io/tutorials/hub/development-mode/
+- https://docs.textile.io/tutorials/hub/user-thread-database/
+
+Then you'll update the environment variables in your deployed app (or if using insecure keys, you can embed them directly, _not shown_):
+
+```
+mv example.env .env
+```
+
+edit `.env`. add your own api key and secret from `hub keys create`, via the Textile Hub CLI.
+
+## App
+
+The app is intentionally simple. All the logic is contained in two files (`App.tsx` and `ThreadService.ts`). We highly recommend you read those files, pick through the doc strings, and explore the room creation and join flow. This is by no means best practices for building web-apps, but it is easy to follow!
+
+## Available Scripts
+
+In the project directory, you can run:
+
+### `npm run start`
+
+Which fires up the development server. This allows you to do hot reload, debugging, and all the nice things that React Scripts provides. This is a regular React app, bootstrapped with create-react-app, so you can see that documentation (https://github.com/facebook/create-react-app) for further details.

--- a/hub-threaddb-chat/src/App.tsx
+++ b/hub-threaddb-chat/src/App.tsx
@@ -71,6 +71,7 @@ class App extends React.Component {
     this.context.getInfoString().then((info: string) => {
       const b = Buffer.from(info)
       this.setState({invite: b.toString('hex')})
+      this.setupObservables()
     })
     this.setState({
       threadID,

--- a/hub-threaddb-chat/src/ThreadService.ts
+++ b/hub-threaddb-chat/src/ThreadService.ts
@@ -25,7 +25,7 @@ export class ThreadService {
     // Create or restore identity from localStorage
     this.identity = await getIdentity()
 
-    /* createCredentials hits the server in my hub example */
+    /* You'll need to include this information in your app */
     const key: KeyInfo = {key: process.env.REACT_APP_API_KEY || ''}
     // We could also consider prefixing the db by identity (or some # of chars from the public key)
     this.db = await Database.withKeyInfo(key, dbName, undefined, process.env.REACT_APP_API) // final variable can be undefined


### PR DESCRIPTION
Fix for some issues we have been having with existing db keys and thread ids. This will explicitly delete an old DB when switching. This might not be useful for a real-world app, but is great for local development and testing examples where you are creating new users and threads frequently. Some comments in the code highlight this. Additionally, because we are using localStorage to store the user's identity, it is important that when testing, _different_ browsers or at least one in incognito mode is used, otherwise, you'll end up with two chat rooms with the same identity... which of course doesn't work. This change now essentially stops that from happening by doing nothing when the same identity will be used to join an existing invite.