### PR TITLE
Basic es modules demo

### DIFF
--- a/3box-identities-ed25519/package.json
+++ b/3box-identities-ed25519/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "3box": "^1.21.0",
     "@emotion/react": "11.0.0-next.12",
-    "@textile/hub": "^5.0.0",
+    "@textile/hub": "^5.0.1",
     "ethers": "^5.0.8",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/basic-es-modules/README.md
+++ b/basic-es-modules/README.md
@@ -1,0 +1,9 @@
+See full [README.md here](../README.md).
+
+Remember to edit `index.html` to include your Hub API key:
+
+```javascript
+...
+const client = await Client.withKeyInfo({ key: 'HUB API KEY HERE' })
+...
+```

--- a/basic-es-modules/index.html
+++ b/basic-es-modules/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8" />
+  <title>Textile ES Modules</title>
+</head>
+
+<body>
+  <script type="module">
+    import { Client, PrivateKey } from "https://unpkg.com/@textile/hub@5.0.1?module";
+
+    // Example identity only. Your users should have their own private keys
+    const PrivateKeyIdentity = 'bbaareqhvbkss57bqe7u2jz3hmoitqntbbdflalqbnmtpm7t7yq7ee5rhyvre23iivcvttvguhghjt2ht4i2dan7zak7v7h55yblnd5cbwe3m2';
+    
+    // Setup the user's PrivateKey identity
+    const identity = PrivateKey.fromString(PrivateKeyIdentity);
+    const h1 = document.createElement('h1');
+    h1.textContent = identity.public.toString();
+    document.body.appendChild(h1);
+
+    async function createAndAuthenticate() {
+      // Connect to the API with hub keys.
+      // Use withUserAuth for production.
+      const client = await Client.withKeyInfo({ key: '' });
+      // Authorize the user to access your Huh api
+      return client.getToken(identity);
+    // Now we're authenticated... start creating buckets or threaddb updates!
+    }
+
+    createAndAuthenticate().then((token) => {
+      console.log(token)
+    });
+  </script>
+</body>
+
+</html>

--- a/basic-es-modules/index.html
+++ b/basic-es-modules/index.html
@@ -22,7 +22,7 @@
     async function createAndAuthenticate() {
       // Connect to the API with hub keys.
       // Use withUserAuth for production.
-      const client = await Client.withKeyInfo({ key: '' });
+      const client = await Client.withKeyInfo({ key: 'HUB API KEY HERE' });
       // Authorize the user to access your Huh api
       return client.getToken(identity);
     // Now we're authenticated... start creating buckets or threaddb updates!

--- a/basic-es-modules/index.html
+++ b/basic-es-modules/index.html
@@ -8,7 +8,7 @@
 
 <body>
   <script type="module">
-    import { Client, PrivateKey } from "https://unpkg.com/@textile/hub@5.0.1?module";
+    import { Client, PrivateKey } from "https://unpkg.com/@textile/hub?module";
 
     // Example identity only. Your users should have their own private keys
     const PrivateKeyIdentity = 'bbaareqhvbkss57bqe7u2jz3hmoitqntbbdflalqbnmtpm7t7yq7ee5rhyvre23iivcvttvguhghjt2ht4i2dan7zak7v7h55yblnd5cbwe3m2';

--- a/bucket-photo-gallery/package.json
+++ b/bucket-photo-gallery/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@textile/hub": "^5.0.0",
+    "@textile/hub": "^5.0.1",
     "@types/jdenticon": "^2.2.0",
     "browser-image-resizer": "^2.1.0",
     "browser-image-size": "^1.1.0",

--- a/hub-browser-auth-app/package.json
+++ b/hub-browser-auth-app/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "@koa/cors": "^3.1.0",
-    "@textile/hub": "^5.0.0",
+    "@textile/hub": "^5.0.1",
     "dotenv": "^8.2.0",
     "emittery": "^0.7.0",
     "jdenticon": "^2.2.0",

--- a/metamask-identities-ed25519/package.json
+++ b/metamask-identities-ed25519/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@emotion/react": "11.0.0-next.12",
-    "@textile/hub": "^5.0.0",
+    "@textile/hub": "^5.0.1",
     "@types/bcryptjs": "^2.4.2",
     "bcryptjs": "^2.4.3",
     "ethers": "^5.0.8",

--- a/react-native-hub-app/package.json
+++ b/react-native-hub-app/package.json
@@ -12,7 +12,7 @@
     "bind": "adb reverse tcp:3007 tcp:3007"
   },
   "dependencies": {
-    "@textile/hub": "^5.0.0",
+    "@textile/hub": "^5.0.1",
     "bad-words": "^3.0.3",
     "buffer": "^4.9.2",
     "events": "^3.1.0",

--- a/simple-auth/package.json
+++ b/simple-auth/package.json
@@ -25,7 +25,7 @@
     "eslint-plugin-promise": "^4.2.1"
   },
   "dependencies": {
-    "@textile/hub": "^5.0.0",
+    "@textile/hub": "^5.0.1",
     "dotenv": "^8.2.0"
   }
 }

--- a/user-mailbox-setup/package.json
+++ b/user-mailbox-setup/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@emotion/react": "11.0.0-next.12",
-    "@textile/hub": "^5.0.0",
+    "@textile/hub": "^5.0.1",
     "ethers": "^5.0.8",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",


### PR DESCRIPTION
This is a pretty simple demo/example of taking advantage of our new ES modules supports in all @textile/* libs. Here, an app in dev mode is used to create a basic HTML app that imports and existing "user" identity, and then authenticates with this user on the hub. It does not create any new data or threads on the hub, and any folks playing with the demo should use their own hub credentials and identities. Copies concepts from the user mailbox demo app.