### PR TITLE
fix: hub-browser-auth-app build error

### DIFF
--- a/hub-browser-auth-app/src/server/wss.ts
+++ b/hub-browser-auth-app/src/server/wss.ts
@@ -59,7 +59,7 @@ const wss = route.all('/ws/userauth', (ctx) => {
                 value: Buffer.from(challenge).toJSON(),
               }))
               /** Wait for the challenge event from our event emitter */
-              emitter.on('challenge', (sig) => {
+              emitter.on('challenge', (sig:any) => {
                 /** Resolve the promise with the challenge response */
                 resolve(Buffer.from(sig))
               });


### PR DESCRIPTION
# Error Message
``` sh
> tsc -p src/server/

src/server/wss.ts:64:37 - error TS2769: No overload matches this call.
  The last overload gave the following error.
    Argument of type 'unknown' is not assignable to parameter of type 'string | { valueOf(): string; } | { [Symbol.toPrimitive](hint: "string"): string; }'.
      Property '[Symbol.toPrimitive]' is missing in type '{}' but required in type '{ [Symbol.toPrimitive](hint: "string"): string; }'.

64                 resolve(Buffer.from(sig))
                                       ~~~

  node_modules/_@types_node@15.0.2@@types/node/globals.d.ts:149:55
    149     static from(str: WithImplicitCoercion<string> | { [Symbol.toPrimitive](hint: 'string'): string }, encoding?: BufferEncoding): Buffer;
                                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    '[Symbol.toPrimitive]' is declared here.
  node_modules/_@types_node@15.0.2@@types/node/globals.d.ts:149:12
    149     static from(str: WithImplicitCoercion<string> | { [Symbol.toPrimitive](hint: 'string'): string }, encoding?: BufferEncoding): Buffer;
                   ~~~~
    The last overload is declared here.


Found 1 error.
```
# Solution
sig => sig:any